### PR TITLE
Remove deprecated sensors const values.

### DIFF
--- a/custom_components/uhoo/__init__.py
+++ b/custom_components/uhoo/__init__.py
@@ -12,8 +12,9 @@ from pyuhoo.device import Device
 from pyuhoo.errors import UhooError, UnauthorizedError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.const import UnitOfPressure, UnitOfTemperature, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core_config import Config
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed

--- a/custom_components/uhoo/const.py
+++ b/custom_components/uhoo/const.py
@@ -8,15 +8,12 @@ from homeassistant.const import (  # noqa:F401
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
-    DEVICE_CLASS_CO,
-    DEVICE_CLASS_CO2,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_PRESSURE,
-    DEVICE_CLASS_TEMPERATURE,
+    UnitOfPressure,
+    UnitOfTemperature,
     PERCENTAGE,
-    PRESSURE_HPA,
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
+)
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
 )
 
 # Base component constants
@@ -51,14 +48,14 @@ UPDATE_INTERVAL = timedelta(seconds=60)
 
 SENSOR_TYPES = {
     API_CO: {
-        ATTR_DEVICE_CLASS: DEVICE_CLASS_CO,
+        ATTR_DEVICE_CLASS: SensorDeviceClass.CO,
         ATTR_ICON: "mdi:molecule-co",
         ATTR_UNIT_OF_MEASUREMENT: CONCENTRATION_PARTS_PER_MILLION,
         ATTR_LABEL: "Carbon monoxide",
         ATTR_UNIQUE_ID: API_CO,
     },
     API_CO2: {
-        ATTR_DEVICE_CLASS: DEVICE_CLASS_CO2,
+        ATTR_DEVICE_CLASS: SensorDeviceClass.CO2,
         ATTR_ICON: "mdi:molecule-co2",
         ATTR_UNIT_OF_MEASUREMENT: CONCENTRATION_PARTS_PER_MILLION,
         ATTR_LABEL: "Carbon dioxide",
@@ -72,7 +69,7 @@ SENSOR_TYPES = {
         ATTR_UNIQUE_ID: API_DUST,
     },
     API_HUMIDITY: {
-        ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
+        ATTR_DEVICE_CLASS: SensorDeviceClass.HUMIDITY,
         ATTR_ICON: "mdi:water-percent",
         ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
         ATTR_LABEL: "Humidity",
@@ -93,16 +90,16 @@ SENSOR_TYPES = {
         ATTR_UNIQUE_ID: API_OZONE,
     },
     API_PRESSURE: {
-        ATTR_DEVICE_CLASS: DEVICE_CLASS_PRESSURE,
+        ATTR_DEVICE_CLASS: SensorDeviceClass.PRESSURE,
         ATTR_ICON: "mdi:gauge",
-        ATTR_UNIT_OF_MEASUREMENT: PRESSURE_HPA,
+        ATTR_UNIT_OF_MEASUREMENT: UnitOfPressure.HPA,
         ATTR_LABEL: "Air pressure",
         ATTR_UNIQUE_ID: API_PRESSURE,
     },
     API_TEMP: {
-        ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+        ATTR_DEVICE_CLASS: SensorDeviceClass.TEMPERATURE,
         ATTR_ICON: "mdi:thermometer",
-        ATTR_UNIT_OF_MEASUREMENT: TEMP_FAHRENHEIT,
+        ATTR_UNIT_OF_MEASUREMENT: UnitOfTemperature.FAHRENHEIT,
         ATTR_LABEL: "Temperature",
         ATTR_UNIQUE_ID: API_TEMP,
     },

--- a/custom_components/uhoo/sensor.py
+++ b/custom_components/uhoo/sensor.py
@@ -3,8 +3,8 @@
 from pyuhoo.device import Device
 
 from custom_components.uhoo import UhooDataUpdateCoordinator
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
-from homeassistant.core import HomeAssistant, UnitOfTemperature
+from homeassistant.components.sensor import SensorStateClass, SensorEntity
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -91,7 +91,7 @@ class UhooSensorEntity(CoordinatorEntity, SensorEntity):
     @property
     def state_class(self) -> str:
         """Return the state class of this entity, from STATE_CLASSES, if any."""
-        return str(STATE_CLASS_MEASUREMENT)
+        return str(SensorStateClass.MEASUREMENT)
 
     @property
     def icon(self) -> str:

--- a/custom_components/uhoo/sensor.py
+++ b/custom_components/uhoo/sensor.py
@@ -4,7 +4,7 @@ from pyuhoo.device import Device
 
 from custom_components.uhoo import UhooDataUpdateCoordinator
 from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, SensorEntity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, UnitOfTemperature
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -20,8 +20,7 @@ from .const import (
     MANUFACTURER,
     MODEL,
     SENSOR_TYPES,
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
+    UnitOfTemperature,
 )
 
 
@@ -104,8 +103,8 @@ class UhooSensorEntity(CoordinatorEntity, SensorEntity):
         """Return unit of measurement."""
         if self._kind == API_TEMP:
             if self._coordinator.user_settings_temp == "f":
-                return str(TEMP_FAHRENHEIT)
+                return str(UnitOfTemperature.FAHRENHEIT)
             else:
-                return str(TEMP_CELSIUS)
+                return str(UnitOfTemperature.CELSIUS)
         else:
             return str(SENSOR_TYPES[self._kind][ATTR_UNIT_OF_MEASUREMENT])

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -18,7 +18,7 @@ from custom_components.uhoo.const import (  # noqa:F401
     ATTR_LABEL,
     SENSOR_TYPES,
 )
-from homeassistant.components.sensor import ATTR_STATE_CLASS, STATE_CLASS_MEASUREMENT
+from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ICON,
@@ -56,7 +56,7 @@ def assert_expected_properties(
     assert state.state == f"{str(MOCK_DEVICE_DATA[sensor_type]['value'])}"
 
     # Attributes
-    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
     assert state.attributes.get(ATTR_ICON) == SENSOR_TYPES[sensor_type][ATTR_ICON]
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)


### PR DESCRIPTION
Resolves [sensors const deprecation in HA 2025 #8](https://github.com/andrewleech/uhoo-homeassistant/issues/8).
Tested with HACS 2.0.3, HA Core 2025.1.0.
![image](https://github.com/user-attachments/assets/5fefd7e2-bcad-4a3d-97c9-76ba68a0bace)
